### PR TITLE
Adding Travis testing for Node.js 4.3 environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.10" # Lambda environment
+  - 4.3
+  - "0.10"
 before_install:
   - npm -g install npm@latest-2
 script:

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 console.log("AWS Lambda SES Forwarder // @arithmetric // Version 2.3.0");
 
 // Configure the S3 bucket and key prefix for stored raw emails, and the


### PR DESCRIPTION
Adding Travis testing for Node.js 4.3 now that it is a supported runtime environment on Lambda:
https://aws.amazon.com/blogs/compute/node-js-4-3-2-runtime-now-available-on-lambda/
