### PR TITLE
Recipient string comparison should be case insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ console.log("AWS Lambda SES Forwarder // @arithmetric // Version 2.3.0");
 //   forward and the value is an array of email addresses to which to send the
 //   message. To match all email addresses on a domain, use a key without the
 //   name part of an email address before the "at" symbol (i.e. `@example.com`).
+//   The key must be lowercase.
 var defaultConfig = {
   fromEmail: "noreply@example.com",
   emailBucket: "s3-bucket-name",
@@ -67,15 +68,16 @@ exports.transformRecipients = function(data, next) {
   var newRecipients = [];
   data.originalRecipients = data.recipients;
   data.recipients.forEach(function(origEmail) {
-    if (data.config.forwardMapping.hasOwnProperty(origEmail)) {
+    var origEmailKey = origEmail.toLowerCase();
+    if (data.config.forwardMapping.hasOwnProperty(origEmailKey)) {
       newRecipients = newRecipients.concat(
-        data.config.forwardMapping[origEmail]);
+        data.config.forwardMapping[origEmailKey]);
       data.originalRecipient = origEmail;
     } else {
       var origEmailDomain;
-      var pos = origEmail.lastIndexOf("@");
+      var pos = origEmailKey.lastIndexOf("@");
       if (pos !== -1) {
-        origEmailDomain = origEmail.slice(pos);
+        origEmailDomain = origEmailKey.slice(pos);
       }
       if (origEmailDomain &&
           data.config.forwardMapping.hasOwnProperty(origEmailDomain)) {

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -17,9 +17,49 @@ describe('index.js', function() {
                 "jim@example.com",
                 "jane@example.com"
               ]
-            },
-            log: console.log
-          }
+            }
+          },
+          context: {
+            succeed: function() {
+              assert.ok(false,
+                'context.succeed() was called, but should not be');
+              done();
+            }
+          },
+          log: console.log
+        };
+        index.transformRecipients(data, function(err, data) {
+          assert.ok(!err, "transformRecipients returned successfully");
+          assert.equal(data.recipients[0],
+            "jim@example.com",
+            "parseEvent made 1/2 substitutions");
+          assert.equal(data.recipients[1],
+            "jane@example.com",
+            "parseEvent made 2/2 substitutions");
+          done();
+        });
+      });
+
+    it('should transform recipients in a case insensitive way',
+      function(done) {
+        var data = {
+          recipients: ["INFO@EXAMPLE.COM"],
+          config: {
+            forwardMapping: {
+              "info@example.com": [
+                "jim@example.com",
+                "jane@example.com"
+              ]
+            }
+          },
+          context: {
+            succeed: function() {
+              assert.ok(false,
+                'context.succeed() was called, but should not be');
+              done();
+            }
+          },
+          log: console.log
         };
         index.transformRecipients(data, function(err, data) {
           assert.ok(!err, "transformRecipients returned successfully");
@@ -36,7 +76,7 @@ describe('index.js', function() {
     it('should transform recipients according a domain wildcard mapping',
       function(done) {
         var data = {
-          recipients: ["info@example.com"],
+          recipients: ["info@EXAMPLE.com"],
           config: {
             forwardMapping: {
               "@example.com": [


### PR DESCRIPTION
The string comparison between the email address in the received email's header and the forwardMapping object's keys should be case insensitive.

Resolves #24.
