### PR TITLE
Made reply-to regex case-insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ exports.processMessage = function(data, next) {
   var body = match && match[2] ? match[2] : '';
 
   // Add "Reply-To:" with the "From" address if it doesn't already exists
-  if (!/^Reply-To: /m.test(header)) {
+  if (!/^Reply-To: /mi.test(header)) {
     match = header.match(/^From: (.*\r?\n)/m);
     var from = match && match[1] ? match[1] : '';
     if (from) {


### PR DESCRIPTION
Some email providers seem to use a `Reply-to` instead of `Reply-To` header, particularly medium.com.  Very minor change to make the regex search for `Reply-To` case-insensitive.