### PR TITLE
Fix loading AWS libraries to improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var AWS = require('aws-sdk');
+
 console.log("AWS Lambda SES Forwarder // @arithmetric // Version 3.0.0");
 
 // Configure the S3 bucket and key prefix for stored raw emails, and the
@@ -260,7 +262,6 @@ exports.handler = function(event, context, overrides) {
   ];
   var step;
   var currentStep = 0;
-  var AWS = require('aws-sdk');
   var data = {
     event: event,
     context: context,


### PR DESCRIPTION
Change initiate AWS SDK from handler to parser time. That can use native Node code-cache and this is not included to billed duration.

### Practical result:
Before
`Duration: 4931.01 ms	Billed Duration: 5000 ms Memory Size: 128 MB	Max Memory Used: 56 MB`
After
`Duration: 2601.95 ms	Billed Duration: 2700 ms Memory Size: 128 MB	Max Memory Used: 32 MB`