### PR TITLE
Fix loading AWS libraries to improve performance (refactored branch)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var AWS = require('aws-sdk');
+
 console.log("AWS Lambda SES Forwarder // @arithmetric // Version 4.0.0");
 
 // Configure the S3 bucket and key prefix for stored raw emails, and the
@@ -257,7 +259,6 @@ exports.handler = function(event, context, callback, overrides) {
     exports.processMessage,
     exports.sendMessage
   ];
-  var AWS = require('aws-sdk');
   var data = {
     event: event,
     callback: callback,


### PR DESCRIPTION
_Same PR as #34, this is for refactored branch_

Change initiate AWS SDK from handler to parser time. That can use native Node code-cache and this is not included to billed duration.

### Practical result:
Before
`Duration: 4931.01 ms	Billed Duration: 5000 ms Memory Size: 128 MB	Max Memory Used: 56 MB`
After
`Duration: 2601.95 ms	Billed Duration: 2700 ms Memory Size: 128 MB	Max Memory Used: 32 MB`