### PR TITLE
Added 'toEmail' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,8 +223,8 @@ exports.processMessage = function(data) {
         return 'Subject: ' + data.config.subjectPrefix + subject;
       });
   }
-  
-  //Replace original 'To' header with a manually defined one
+
+  // Replace original 'To' header with a manually defined one
   if (data.config.toEmail) {
     header = header.replace(/^To: (.*)/mg, () => 'To: ' + data.config.toEmail);
   }

--- a/index.js
+++ b/index.js
@@ -223,6 +223,11 @@ exports.processMessage = function(data) {
         return 'Subject: ' + data.config.subjectPrefix + subject;
       });
   }
+  
+  //Replace original 'To' header with a manually defined one
+  if (data.config.toEmail) {
+    header = header.replace(/^To: (.*)/mg, () => 'To: ' + data.config.toEmail);
+  }
 
   // Remove the Return-Path header.
   header = header.replace(/^Return-Path: (.*)\r?\n/mg, '');

--- a/test/assets/message.toemail.txt
+++ b/test/assets/message.toemail.txt
@@ -1,0 +1,25 @@
+Received: from example.com (example.com [127.0.0.1])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 81fu1unjk93bm5cb0jlk23fll33spcvf3633l8qg1
+ for info@example.com;
+ Fri, 11 Mar 2016 06:20:55 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domain of example.com) client-ip=10.0.0.1; envelope-from=postmaster@example.com; helo=example.com;
+From: Betsy <noreply@example.com>
+To: actualTarget@example.com
+Subject: Test message from Betsy
+Message-Id: <B9ebWRD-000123-3K@example.com>
+Date: Fri, 11 Mar 2016 01:20:54 -0500
+Reply-To: Betsy <betsy@example.com>
+
+This is a test message to info@example.com.
+
+It was sent from betsy@example.com.
+
+These lines should not be affected:
+From: test@example.com
+Reply-To: test@example.com
+Return-Path: test@example.com
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=gdwg2y3kokkkomn55z2ilkup5wp5hhxx; d=amazonses.com; t=1457977483;
+	h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version;

--- a/test/assets/message.toemail.txt
+++ b/test/assets/message.toemail.txt
@@ -5,7 +5,7 @@ Received: from example.com (example.com [127.0.0.1])
 X-SES-Spam-Verdict: PASS
 X-SES-Virus-Verdict: PASS
 Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domain of example.com) client-ip=10.0.0.1; envelope-from=postmaster@example.com; helo=example.com;
-From: Betsy <noreply@example.com>
+From: Betsy at betsy@example.com <info@example.com>
 To: actualTarget@example.com
 Subject: Test message from Betsy
 Message-Id: <B9ebWRD-000123-3K@example.com>

--- a/test/processMessage.js
+++ b/test/processMessage.js
@@ -124,5 +124,31 @@ describe('index.js', function() {
           done();
         });
     });
+    
+    
+    it('should allow overriding the To header in emails', function(done) {
+      var data = {
+        config: {
+          toEmail: "actualTarget@example.com"
+        },
+        email: {
+          source: "betsy@example.com"
+        },
+        emailData:
+          fs.readFileSync("test/assets/message.txt").toString(),
+        log: console.log,
+        recipients: ["jim@example.com"],
+        originalRecipient: "info@example.com"
+      };
+      var emailDataProcessed = fs.readFileSync(
+        "test/assets/message.toemail.txt").toString();
+      index.processMessage(data)
+        .then(function(data) {
+          assert.equal(data.emailData,
+            emailDataProcessed,
+            "processEmail updated email data");
+          done();
+        });
+    });
   });
 });

--- a/test/processMessage.js
+++ b/test/processMessage.js
@@ -124,8 +124,7 @@ describe('index.js', function() {
           done();
         });
     });
-    
-    
+
     it('should allow overriding the To header in emails', function(done) {
       var data = {
         config: {


### PR DESCRIPTION
This option is relevant, if you actually want to hide the original To header instead of directly forwarding the original email.
For me this is necessary, since the original 'To:' email should not be included in the forwarded email, to make the process as transparent to the receiver as possible. 

Note: For me, this option does only make sense, if I also use the "fromEmail" option. Otherwise the "From:" header is set to the value of the original "To:" header, which would include the original email destination, too.