### PR TITLE
Fix Duplicate header 'Message-ID' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,6 +235,9 @@ exports.processMessage = function(data) {
   // Remove Sender header.
   header = header.replace(/^Sender: (.*)\r?\n/mg, '');
 
+  // Remove Sender header.
+  header = header.replace(/^Message-ID: (.*)\r?\n/mig, '');
+
   // Remove all DKIM-Signature headers to prevent triggering an
   // "InvalidParameterValue: Duplicate header 'DKIM-Signature'" error.
   // These signatures will likely be invalid anyways, since the From

--- a/test/assets/message.fromemail.txt
+++ b/test/assets/message.fromemail.txt
@@ -8,7 +8,6 @@ Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domai
 From: Betsy <noreply@example.com>
 To: info@example.com
 Subject: Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-To: Betsy <betsy@example.com>
 

--- a/test/assets/message.processed.txt
+++ b/test/assets/message.processed.txt
@@ -8,7 +8,6 @@ Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domai
 From: Betsy at betsy@example.com <info@example.com>
 To: info@example.com
 Subject: Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-To: Betsy <betsy@example.com>
 

--- a/test/assets/message.replyto.txt
+++ b/test/assets/message.replyto.txt
@@ -18,7 +18,6 @@ DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=yahoo.com; s=s2048; t=14
 From: Betsy <betsy@example.com>
 To: info@example.com
 Subject: Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-To: Betsy <betsy@example.com>
 

--- a/test/assets/message.replyto_case.processed.txt
+++ b/test/assets/message.replyto_case.processed.txt
@@ -8,7 +8,6 @@ Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domai
 From: Betsy at betsy@example.com <info@example.com>
 To: info@example.com
 Subject: Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-to: Betsy <betsy@example.com>
 

--- a/test/assets/message.subjectprefix.txt
+++ b/test/assets/message.subjectprefix.txt
@@ -8,7 +8,6 @@ Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domai
 From: Betsy at betsy@example.com <info@example.com>
 To: info@example.com
 Subject: [PREFIX] Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-To: Betsy <betsy@example.com>
 

--- a/test/assets/message.toemail.txt
+++ b/test/assets/message.toemail.txt
@@ -8,7 +8,6 @@ Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domai
 From: Betsy at betsy@example.com <info@example.com>
 To: actualTarget@example.com
 Subject: Test message from Betsy
-Message-Id: <B9ebWRD-000123-3K@example.com>
 Date: Fri, 11 Mar 2016 01:20:54 -0500
 Reply-To: Betsy <betsy@example.com>
 

--- a/test/assets/message.txt
+++ b/test/assets/message.txt
@@ -13,6 +13,7 @@ DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
 	NTuhRooMHNWMDJgEdo84jnDXIqKSvPR8o0y45M7I=
 X-SES-Spam-Verdict: PASS
 X-SES-Virus-Verdict: PASS
+Message-ID: <duplicit-invalid-messageid@localhost>
 Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domain of example.com) client-ip=10.0.0.1; envelope-from=postmaster@example.com; helo=example.com;
 DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=yahoo.com; s=s2048; t=1457977479; bh=yu5f99IGBuY/QbF1MYj9KjHmHUGQlS13FY53b5YLEb8=; h=Date:From:Reply-To:To:Subject:References:From:Subject; b=Osl8Z/p7lL3v/D60aBh3AJ5coNE6AORIwAEOa66ogh8UI1GLbTo0JgRwN0amg4n8lOU2RJyyNR10+rfx1ciwiP8ypfs0GjllxhgoeXtxCqtsdil5ILvkrxVloOH84tkKDVrvWv0xtZ4S1kOUDVY0EoBnC9xx7dU+WkNA2YmQSQgEji0jb8OeWowvOFxUsIwURewzONCMLm6+ZJqAVVediv6td3U3NRlN3Nfm7IHO8uxvQdDLTbJhqmIx3Ld5x///G9DOkclE+2pHgX0xZwOsbkPsfRRyeDWlrjPWwU2Wm8E481U0CsjmaEbSwk4lkEoFKQH7WfvmULFXftK0YZZMjA==
 From: Betsy <betsy@example.com>


### PR DESCRIPTION
These can fix #52 errors.

Reason: Some senders sending invalid messages with duplicit `Message-ID` header ([example](https://twitter.com/JakubBoucek/status/876116031512641538)). Someone even invalid letter case in header name (`Message-Id` instead of `Message-ID` according to [RFC 2822](https://tools.ietf.org/html/rfc2822#section-3.6.4)). 

Even though [AWS SES drop this header](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/header-fields.html) during message send, it patently checks it.

All tests added.