### PR TITLE
Support for dynamic list of recipients

### DIFF
--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,49 @@
+
+/* global describe, it */
+
+let assert = require("assert");
+
+require("../index");
+
+describe('index.js', function() {
+  describe('#Promise.settle()', function() {
+    it('should fulfill on empty array',
+      function(done) {
+        let promises = [];
+        Promise.settle(promises)
+          .then(function(values) {
+            assert.equal(values.length,
+              0,
+              "Promise.settle fulfills on empty array");
+            done();
+          });
+      });
+
+    it('should fulfill on invalid array',
+        function(done) {
+          let promises = ['invalid'];
+          Promise.settle(promises)
+          .then(function(values) {
+            assert.equal(values.length,
+                0,
+                "Promise.settle fulfills on invalid array");
+            done();
+          });
+        });
+
+    it('should fulfill with rejected items',
+        function(done) {
+          let promises = [Promise.reject()];
+          Promise.settle(promises)
+          .then(function(values) {
+            assert.strictEqual(values[0],
+                undefined,
+                "Promise.settle 1/2 fulfills with rejected items");
+            assert.equal(values.length,
+                1,
+                "Promise.settle 2/2 fulfills with rejected items");
+            done();
+          });
+        });
+  });
+});

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -113,6 +113,171 @@ describe('index.js', function() {
           });
       });
 
+    it('should accept Promises as recipient addresses',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            config: {
+              forwardMapping: {
+                "info@example.com": [
+                  Promise.resolve("jim@example.com"),
+                  Promise.resolve("jane@example.com")
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients[0],
+                "jim@example.com",
+                "parseEvent made 1/2 substitutions");
+            assert.equal(data.recipients[1],
+                "jane@example.com",
+                "parseEvent made 2/2 substitutions");
+            done();
+          });
+        });
+
+    it('should accept functions as recipient addresses',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            config: {
+              forwardMapping: {
+                "info@example.com": [
+                  () => "jim@example.com",
+                  () => Promise.resolve("jane@example.com"),
+                  () => {
+                    return new Promise(function(resolve) {
+                      setTimeout(() => {
+                        resolve("bob@example.com");
+                      }, 10);
+                    });
+                  }
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients[0],
+                "jim@example.com",
+                "parseEvent made 1/3 substitutions");
+            assert.equal(data.recipients[1],
+                "jane@example.com",
+                "parseEvent made 2/3 substitutions");
+            assert.equal(data.recipients[2],
+                "bob@example.com",
+                "parseEvent made 3/3 substitutions");
+            done();
+          });
+        });
+
+    it('functions should have access to data bundle',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            contextVar: "contextValue",
+            config: {
+              forwardMapping: {
+                "info@example.com": [
+                  data => data.contextVar
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients[0],
+                "contextValue",
+                "parseEvent has correct context value");
+            done();
+          });
+        });
+
+    it('should return no recipients (no skipRejectedRecipients in config)',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            config: {
+              forwardMapping: {
+                "info@example.com": [
+                  () => "jim@example.com",
+                  () => "jane@example.com",
+                  () => Promise.reject("Test rejection")
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients.length,
+                0,
+                "parseEvent recipients was rejected");
+            done();
+          });
+        });
+
+    it('should return no recipients (skipRejectedRecipients=false)',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            config: {
+              skipRejectedRecipients: false,
+              forwardMapping: {
+                "info@example.com": [
+                  () => "jim@example.com",
+                  () => "jane@example.com",
+                  () => Promise.reject("Test rejection")
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients.length,
+                0,
+                "parseEvent recipients was rejected");
+            done();
+          });
+        });
+
+    it('should skip rejected recipients (skipRejectedRecipients=true)',
+        function(done) {
+          var data = {
+            recipients: ["info@example.com"],
+            config: {
+              skipRejectedRecipients: true,
+              forwardMapping: {
+                "info@example.com": [
+                  () => "jim@example.com",
+                  () => Promise.reject("Test rejection"),
+                  () => "jane@example.com"
+                ]
+              }
+            },
+            context: {},
+            log: console.log
+          };
+          index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients.length,
+                2,
+                "parseEvent rejected recipients was skipped");
+            done();
+          });
+        });
+
     it('should exit if there are no new recipients',
       function(done) {
         var data = {


### PR DESCRIPTION
Summary
---
1. Add support for functions/Promises in `forwardMapping` recipients list.
For example:
```
{
  ...
  forwardMapping: {
    "info@example.com": [
      Promise.resolve("jim@example.com"),
      () => Promise.resolve("jane@example.com"),
      data => {
         // do some stuff
         return "bob@example.com";
      }
    ]
  },
  ...
}
```
2. New config option `skipRejectedRecipients` (boolean). If `true` all rejected promises in `forwardMapping` will be silently ignored. If `false` (by default) any rejected promise will cancel forwarding (may be used for validation).

Examples
---
1. Validate incoming emails and send junk messages into a separate mailbox:
```
{
  ...
  forwardMapping: {
    "info@example.com": [
      data => {
        let dataReceipt = data.event.Records[0].ses.receipt;
        if (dataReceipt.spamVerdict.status !== 'PASS' ||
            dataReceipt.dkimVerdict.status !== 'PASS' ||
            dataReceipt.spfVerdict.status !== 'PASS' ||
            dataReceipt.virusVerdict.status !== 'PASS') {  
          return 'junk@example.com';
        } else {
          return 'office@example.com';
        }
      }
    ]
  }
}
```
2. Check for custom header and stop forwarding if check fails:
```
{
  ...
  skipRejectedRecipients: false,
  forwardMapping: {
    "info@example.com": [
      'office@example.com',
      data => {
        let headers = data.event.Records[0].ses.mail.headers;
        let header = headers.find(h => h.name === 'X-MyCompany-Signature');
        if (!header || header.value !== 'VALID-SIGNATURE') {  
          return Promise.reject('Invalid signature');
        }
        // Empty values will be ignored so return nothing
      }
    ]
  }
}
```
3. Get list of recipients from remote source:
```
{
  ...
  skipRejectedRecipients: true,
  forwardMapping: {
    "info@example.com": [
      'office@example.com',
      () => {
        // If returned Promise will be rejected due to errors, message will be forwarded to office@example.com only
        return MyAwesomeApi.getEmails() // example response: jane@example.com, bob@example.com
          .then(list => {
            // It is ok to return array of email addresses
            return list.split(/\s*,\s*/); // output: [ "jane@example.com", "bob@example.com" ]
          })
      }
    ]
  }
}
```