### PR TITLE
Added support for a "@" catch all recipient evaluated last

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ exports.transformRecipients = function(data) {
         newRecipients = newRecipients.concat(
           data.config.forwardMapping[origEmailUser]);
         data.originalRecipient = origEmail;
+      } else if (data.config.forwardMapping.hasOwnProperty("@")) {
+        newRecipients = newRecipients.concat(
+          data.config.forwardMapping["@"]);
+        data.originalRecipient = origEmail;
       }
     }
   });

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -172,5 +172,30 @@ describe('index.js', function() {
         };
         index.transformRecipients(data);
       });
+
+    it('should support matching with catch all',
+      function(done) {
+        var data = {
+          recipients: ["info@example.com"],
+          config: {
+            forwardMapping: {
+              "no-match@example.com": [
+                "jim@example.com"
+              ],
+              "@": [
+                "catch-all@example.com"
+              ]
+            }
+          },
+          log: console.log
+        };
+        index.transformRecipients(data)
+          .then(function(data) {
+            assert.equal(data.recipients[0],
+              "catch-all@example.com",
+              "parseEvent made substitution");
+            done();
+          });
+      });
   });
 });


### PR DESCRIPTION
Added the possibility to add a _catch all_ recipient if no other recipient is matched. This is good if the same lambda is used for multiple domains that should all be forwarded to the same recipient. New domains can then be added without any need to modify the Lamda.