### PR TITLE
RFC: Add Support for SMTP Server

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,16 @@ var defaultConfig = {
   // Uncomment this if you want to use smtp instead of SES
   //smtp_info: {
   //  region: "aws-region",
-  //  // The aws secret contains the 
+  //  // The aws secret contains the
+  //  // smtp server info.
   //  secretName: "name of aws secret",
+  //  // The AWS Secret should look like.
+  //  //  {
+  //  //  "server": "smtp.server",
+  //  //  "username": "username",
+  //  //  "password": "secret password",
+  //  //  "port": "port-number"
+  //  //  }
   //},
   fromEmail: "noreply@example.com",
   subjectPrefix: "",


### PR DESCRIPTION
Don't actually merge this.  The tests haven't been updated and I don't like the way the smtp code has been hooked in.

This code allows the use of an SMTP server instead of SES to forward the email.  AWS and Google are not playing nice currently and Google is bouncing a lot of email coming through AWS.  Since most of our mail forwarding goes to Google, this is a problem for us.  I've modified the code to use authenticated SMTP and log into gmail, so we can reliably send mail to gmail.

This totally violates the purpose of an SES forwarder, but is still useful. So I wanted to gauge interest to see if I should clean up the changes and submit them for as a real pull request.