### PR TITLE
Fix expected field headers format

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ exports.processMessage = function(data) {
   var body = match && match[2] ? match[2] : '';
 
   // Add "Reply-To:" with the "From" address if it doesn't already exists
-  if (!/^Reply-To: /mi.test(header)) {
-    match = header.match(/^From: (.*(?:\r?\n\s+.*)*\r?\n)/m);
+  if (!/^reply-to:\s?/mi.test(header)) {
+    match = header.match(/^from:\s?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
     var from = match && match[1] ? match[1] : '';
     if (from) {
       header = header + 'Reply-To: ' + from;
@@ -202,7 +202,7 @@ exports.processMessage = function(data) {
   // so replace the message's "From:" header with the original
   // recipient (which is a verified domain)
   header = header.replace(
-    /^From: (.*(?:\r?\n\s+.*)*)/mg,
+    /^from:\s?(.*(?:\r?\n\s+.*)*)/mgi,
     function(match, from) {
       var fromText;
       if (data.config.fromEmail) {
@@ -218,7 +218,7 @@ exports.processMessage = function(data) {
   // Add a prefix to the Subject
   if (data.config.subjectPrefix) {
     header = header.replace(
-      /^Subject: (.*)/mg,
+      /^subject:\s?(.*)/mgi,
       function(match, subject) {
         return 'Subject: ' + data.config.subjectPrefix + subject;
       });
@@ -226,23 +226,23 @@ exports.processMessage = function(data) {
 
   // Replace original 'To' header with a manually defined one
   if (data.config.toEmail) {
-    header = header.replace(/^To: (.*)/mg, () => 'To: ' + data.config.toEmail);
+    header = header.replace(/^to:\s?(.*)/mgi, () => 'To: ' + data.config.toEmail);
   }
 
   // Remove the Return-Path header.
-  header = header.replace(/^Return-Path: (.*)\r?\n/mg, '');
+  header = header.replace(/^return-path:\s?(.*)\r?\n/mgi, '');
 
   // Remove Sender header.
-  header = header.replace(/^Sender: (.*)\r?\n/mg, '');
+  header = header.replace(/^sender:\s?(.*)\r?\n/mgi, '');
 
   // Remove Message-ID header.
-  header = header.replace(/^Message-ID: (.*)\r?\n/mig, '');
+  header = header.replace(/^message-id:\s?(.*)\r?\n/mgi, '');
 
   // Remove all DKIM-Signature headers to prevent triggering an
   // "InvalidParameterValue: Duplicate header 'DKIM-Signature'" error.
   // These signatures will likely be invalid anyways, since the From
   // header was modified.
-  header = header.replace(/^DKIM-Signature: .*\r?\n(\s+.*\r?\n)*/mg, '');
+  header = header.replace(/^dkim-signature:\s?.*\r?\n(\s+.*\r?\n)*/mgi, '');
 
   data.emailData = header + body;
   return Promise.resolve(data);

--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ exports.processMessage = function(data) {
   var body = match && match[2] ? match[2] : '';
 
   // Add "Reply-To:" with the "From" address if it doesn't already exists
-  if (!/^reply-to:\s?/mi.test(header)) {
-    match = header.match(/^from:\s?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
+  if (!/^reply-to:[\t ]?/mi.test(header)) {
+    match = header.match(/^from:[\t ]?(.*(?:\r?\n\s+.*)*\r?\n)/mi);
     var from = match && match[1] ? match[1] : '';
     if (from) {
       header = header + 'Reply-To: ' + from;
@@ -202,7 +202,7 @@ exports.processMessage = function(data) {
   // so replace the message's "From:" header with the original
   // recipient (which is a verified domain)
   header = header.replace(
-    /^from:\s?(.*(?:\r?\n\s+.*)*)/mgi,
+    /^from:[\t ]?(.*(?:\r?\n\s+.*)*)/mgi,
     function(match, from) {
       var fromText;
       if (data.config.fromEmail) {
@@ -218,7 +218,7 @@ exports.processMessage = function(data) {
   // Add a prefix to the Subject
   if (data.config.subjectPrefix) {
     header = header.replace(
-      /^subject:\s?(.*)/mgi,
+      /^subject:[\t ]?(.*)/mgi,
       function(match, subject) {
         return 'Subject: ' + data.config.subjectPrefix + subject;
       });
@@ -226,23 +226,23 @@ exports.processMessage = function(data) {
 
   // Replace original 'To' header with a manually defined one
   if (data.config.toEmail) {
-    header = header.replace(/^to:\s?(.*)/mgi, () => 'To: ' + data.config.toEmail);
+    header = header.replace(/^to:[\t ]?(.*)/mgi, () => 'To: ' + data.config.toEmail);
   }
 
   // Remove the Return-Path header.
-  header = header.replace(/^return-path:\s?(.*)\r?\n/mgi, '');
+  header = header.replace(/^return-path:[\t ]?(.*)\r?\n/mgi, '');
 
   // Remove Sender header.
-  header = header.replace(/^sender:\s?(.*)\r?\n/mgi, '');
+  header = header.replace(/^sender:[\t ]?(.*)\r?\n/mgi, '');
 
   // Remove Message-ID header.
-  header = header.replace(/^message-id:\s?(.*)\r?\n/mgi, '');
+  header = header.replace(/^message-id:[\t ]?(.*)\r?\n/mgi, '');
 
   // Remove all DKIM-Signature headers to prevent triggering an
   // "InvalidParameterValue: Duplicate header 'DKIM-Signature'" error.
   // These signatures will likely be invalid anyways, since the From
   // header was modified.
-  header = header.replace(/^dkim-signature:\s?.*\r?\n(\s+.*\r?\n)*/mgi, '');
+  header = header.replace(/^dkim-signature:[\t ]?.*\r?\n(\s+.*\r?\n)*/mgi, '');
 
   data.emailData = header + body;
   return Promise.resolve(data);

--- a/test/assets/message.txt
+++ b/test/assets/message.txt
@@ -16,7 +16,7 @@ X-SES-Virus-Verdict: PASS
 Message-ID: <duplicit-invalid-messageid@localhost>
 Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domain of example.com) client-ip=10.0.0.1; envelope-from=postmaster@example.com; helo=example.com;
 DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=yahoo.com; s=s2048; t=1457977479; bh=yu5f99IGBuY/QbF1MYj9KjHmHUGQlS13FY53b5YLEb8=; h=Date:From:Reply-To:To:Subject:References:From:Subject; b=Osl8Z/p7lL3v/D60aBh3AJ5coNE6AORIwAEOa66ogh8UI1GLbTo0JgRwN0amg4n8lOU2RJyyNR10+rfx1ciwiP8ypfs0GjllxhgoeXtxCqtsdil5ILvkrxVloOH84tkKDVrvWv0xtZ4S1kOUDVY0EoBnC9xx7dU+WkNA2YmQSQgEji0jb8OeWowvOFxUsIwURewzONCMLm6+ZJqAVVediv6td3U3NRlN3Nfm7IHO8uxvQdDLTbJhqmIx3Ld5x///G9DOkclE+2pHgX0xZwOsbkPsfRRyeDWlrjPWwU2Wm8E481U0CsjmaEbSwk4lkEoFKQH7WfvmULFXftK0YZZMjA==
-From: Betsy <betsy@example.com>
+from:Betsy <betsy@example.com>
 To: info@example.com
 Subject: Test message from Betsy
 Message-Id: <B9ebWRD-000123-3K@example.com>


### PR DESCRIPTION
Fixes #86.

As described in the [RFC 5322 – Internet Message Format](https://www.rfc-editor.org/rfc/rfc5322.txt), `from:Betsy <betsy@example.com>` should be accepted and understood.

Basically, fields don't have to look like `From: ccjmne@gmail.com`, they could very well be: `from:ccjmne@gmail.com` (note the **non-capitalized** field header and the **absence of a whitespace** immediately following the colon `:`).

I ensured this would work for the relevant fields, and slightly modified the `test/assets/message.txt` file to reproduce the uncommon **"lowercase header, colon, no-space, body"** field pattern.

---

Also, according to that same RFC, the "carriage return/line feed" pair should **always** appear together.
In other words, `\r?\n` should really be: `\r\n` ; but I figure it's safe being too lenient there so I'll leave these unchanged.