### PR TITLE
Added a stop_rule_set callback after a successful message processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ Otherwise, you can use an existing one.
  object key prefix. Leave Encrypt Message unchecked and SNS Topic set to [none].
 
  - For the Lambda action: Choose the SesForwarder Lambda function. Leave
- Invocation Type set to Event and SNS Topic set to [none].
+ Invocation Type set to Event and SNS Topic set to [RequestResponse].
+
+ - Set the SNS topic for the Stop Action to a topic that will handle any emails
+  that fail to process. The SNS topic can be subscribed to by an email address.
 
  - Finish by naming the rule, ensuring it's enabled and that spam and virus
  checking are used.

--- a/index.js
+++ b/index.js
@@ -312,7 +312,8 @@ exports.handler = function(event, context, callback, overrides) {
   Promise.series(steps, data)
     .then(function(data) {
       data.log({level: "info", message: "Process finished successfully."});
-      return data.callback();
+      // Success: Let SES know to stop the rule set processing.
+      callback(null, { disposition: 'stop_rule_set', });
     })
     .catch(function(err) {
       data.log({level: "error", message: "Step returned error: " + err.message,


### PR DESCRIPTION
Currently the lambda call is delegated without checking to see if it is successful or not.

This change updates the success case to send a callback to tell the rules to stop processing.  It also updates the README to configure the rules to expect a response, and to recommend adding a SNS topic at the last step, in case there is ever any failure in the processing.


