### PR TITLE
Prevent duplicate subjectPrefix, transition to .strictEqual

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ exports.processMessage = function(data) {
     header = header.replace(
       /^subject:[\t ]?(.*)/mgi,
       function(match, subject) {
-        return 'Subject: ' + data.config.subjectPrefix + subject;
+          return `Subject: ${subject.includes(data.config.subjectPrefix) ? '' : data.config.subjectPrefix}${subject}`;
       });
   }
 

--- a/test/assets/message.existing_subjectprefix.txt
+++ b/test/assets/message.existing_subjectprefix.txt
@@ -1,0 +1,35 @@
+Return-Path: <betsy@example.com>
+Received: from example.com (example.com [127.0.0.1])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 81fu1unjk93bm5cb0jlk23fll33spcvf3633l8qg1
+ for info@example.com;
+ Fri, 11 Mar 2016 06:20:55 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=gdwg2y3kokomn5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1457977483; h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version:Content-Type;
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=gdwg2y3kokkkomn55z2ilkup5wp5hhxx; d=amazonses.com; t=1457977483;
+	h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version:Content-Type:References:Feedback-ID;
+	bh=yu5f22IGBuY/QbF1MYj9KjHbPKMQlS13FY53b5YLEb8=;
+	b=EX4NWAbgp5EuCQ6WzaNg74GiPRxNV/oPWHbd/QAyZmfutsD2Dzr6HYfA2XJ0aEui
+	/RRmYfnjvB8lk3MJRhL/TMHDO/LCWLnXV4OLgkZH6IuVFVZnI2p9pAG11E1AWD9l8AW
+	NTuhRooMHNWMDJgEdo84jnDXIqKSvPR8o0y45M7I=
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Message-ID: <duplicit-invalid-messageid@localhost>
+Received-SPF: none (spfCheck: 127.0.0.1 is neither permitted nor denied by domain of example.com) client-ip=10.0.0.1; envelope-from=postmaster@example.com; helo=example.com;
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=yahoo.com; s=s2048; t=1457977479; bh=yu5f99IGBuY/QbF1MYj9KjHmHUGQlS13FY53b5YLEb8=; h=Date:From:Reply-To:To:Subject:References:From:Subject; b=Osl8Z/p7lL3v/D60aBh3AJ5coNE6AORIwAEOa66ogh8UI1GLbTo0JgRwN0amg4n8lOU2RJyyNR10+rfx1ciwiP8ypfs0GjllxhgoeXtxCqtsdil5ILvkrxVloOH84tkKDVrvWv0xtZ4S1kOUDVY0EoBnC9xx7dU+WkNA2YmQSQgEji0jb8OeWowvOFxUsIwURewzONCMLm6+ZJqAVVediv6td3U3NRlN3Nfm7IHO8uxvQdDLTbJhqmIx3Ld5x///G9DOkclE+2pHgX0xZwOsbkPsfRRyeDWlrjPWwU2Wm8E481U0CsjmaEbSwk4lkEoFKQH7WfvmULFXftK0YZZMjA==
+from:Betsy <betsy@example.com>
+To: info@example.com
+Subject: [PREFIX] Test message from Betsy
+Message-Id: <B9ebWRD-000123-3K@example.com>
+Date: Fri, 11 Mar 2016 01:20:54 -0500
+
+This is a test message to info@example.com.
+
+It was sent from betsy@example.com.
+
+These lines should not be affected:
+From: test@example.com
+Reply-To: test@example.com
+Return-Path: test@example.com
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=gdwg2y3kokkkomn55z2ilkup5wp5hhxx; d=amazonses.com; t=1457977483;
+	h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version;

--- a/test/fetchMessage.js
+++ b/test/fetchMessage.js
@@ -35,7 +35,7 @@ describe('index.js', function() {
         };
         index.fetchMessage(data)
           .then(function(data) {
-            assert.equal(data.emailData,
+            assert.strictEqual(data.emailData,
               "email data",
               "fetchMessage returned email data");
             done();

--- a/test/parseEvent.js
+++ b/test/parseEvent.js
@@ -16,13 +16,13 @@ describe('index.js', function() {
       };
       index.parseEvent(data)
         .then(function(data) {
-          assert.equal(data.email.messageId,
+          assert.strictEqual(data.email.messageId,
             "o3vrnil0e2ic28trm7dakrc2v0clambda4nbp0g1",
             "parseEvent found messageId");
-          assert.equal(data.email.source,
+          assert.strictEqual(data.email.source,
             "janedoe@example.com",
             "parseEvent found message source");
-          assert.equal(data.recipients[0],
+          assert.strictEqual(data.recipients[0],
             "info@example.com",
             "parseEvent found message recipients");
           done();

--- a/test/processMessage.js
+++ b/test/processMessage.js
@@ -151,6 +151,30 @@ describe('index.js', function() {
         });
     });
 
+    it('should not duplicate the subject prefix', function(done) {
+      var data = {
+        config: {
+          subjectPrefix: "[PREFIX] "
+        },
+        email: {
+          source: "betsy@example.com"
+        },
+        emailData: fs.readFileSync("test/assets/message.existing_subjectprefix.txt").toString(),
+        log: console.log,
+        recipients: ["jim@example.com"],
+        originalRecipient: "info@example.com"
+      };
+      var emailDataProcessed = fs.readFileSync(
+        "test/assets/message.subjectprefix.txt").toString();
+      index.processMessage(data)
+        .then(function(data) {
+          assert.equal(data.emailData,
+            emailDataProcessed,
+            "processEmail updated email data");
+          done();
+        });
+    });
+
     it('should allow overriding the To header in emails', function(done) {
       var data = {
         config: {

--- a/test/transformRecipients.js
+++ b/test/transformRecipients.js
@@ -23,10 +23,10 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made 1/2 substitutions");
-            assert.equal(data.recipients[1],
+            assert.strictEqual(data.recipients[1],
               "jane@example.com",
               "parseEvent made 2/2 substitutions");
             done();
@@ -49,10 +49,10 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made 1/2 substitutions");
-            assert.equal(data.recipients[1],
+            assert.strictEqual(data.recipients[1],
               "jane@example.com",
               "parseEvent made 2/2 substitutions");
             done();
@@ -75,10 +75,10 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made 1/2 substitutions");
-            assert.equal(data.recipients[1],
+            assert.strictEqual(data.recipients[1],
               "jane@example.com",
               "parseEvent made 2/2 substitutions");
             done();
@@ -101,10 +101,10 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made 1/2 substitutions");
-            assert.equal(data.recipients[1],
+            assert.strictEqual(data.recipients[1],
               "jane@example.com",
               "parseEvent made 2/2 substitutions");
             done();
@@ -145,7 +145,7 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made substitution");
             done();
@@ -187,7 +187,7 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "jim@example.com",
               "parseEvent made substitution");
             done();
@@ -212,7 +212,7 @@ describe('index.js', function() {
         };
         index.transformRecipients(data)
           .then(function(data) {
-            assert.equal(data.recipients[0],
+            assert.strictEqual(data.recipients[0],
               "catch-all@example.com",
               "parseEvent made substitution");
             done();


### PR DESCRIPTION
Hey!

Just a quick PR to prevent duplicate subjectPrefixes. I also transitioned us to `assert.strictEqual` since `assert.equal` is now deprecated.

Cheers! 🍻